### PR TITLE
feat(ac-button): changed button spacing

### DIFF
--- a/src/components/atoms/ac-button/ac-button.scss
+++ b/src/components/atoms/ac-button/ac-button.scss
@@ -13,7 +13,7 @@ ac-button {
     display: inline-flex;
     box-sizing: border-box;
     align-items: center;
-    min-width: $ac-button__height;
+    min-width: 100px;
     height: $ac-button__height;
     padding: $spacer-tiny $spacer-tiny;
     transition: box-shadow $slow-transition,
@@ -32,9 +32,14 @@ ac-button {
     user-select: none;
     -webkit-appearance: none;
 
+    & > i {
+      margin-left: 8px;
+    }
+
     .ac-button__text {
       padding: 0 $spacer-tiny;
       white-space: nowrap;
+      margin: auto;
     }
   }
 }
@@ -173,6 +178,7 @@ ac-button.ac-button--icon-only {
     align-items: center;
     justify-content: center;
     width: 100%;
+    min-width: $ac-button__height;
     padding: 0;
   }
 }

--- a/src/components/atoms/ac-button/ac-button.scss
+++ b/src/components/atoms/ac-button/ac-button.scss
@@ -32,8 +32,11 @@ ac-button {
     user-select: none;
     -webkit-appearance: none;
 
-    & > i {
+    & > [slot="icon-start"] {
       margin-left: 8px;
+    }
+    & > [slot="icon-end"] {
+      margin-right: 8px;
     }
 
     .ac-button__text {

--- a/src/components/atoms/ac-button/ac-button.tsx
+++ b/src/components/atoms/ac-button/ac-button.tsx
@@ -101,8 +101,8 @@ export class AcButton implements ComponentInterface {
           {this.loading && <AcFaIcon icon={faSpinner} size={14} anim="spin" style={{width: '14px'}}/>}
           <slot name="icon-start"/>
           <span class="ac-button__text">
-          <slot/>
-        </span>
+            <slot/>
+          </span>
           <slot name="icon-end"/>
         </TagType>
       </Host>

--- a/src/index.html
+++ b/src/index.html
@@ -99,6 +99,13 @@
             <ac-button theme="primary" size="small">
               Teste
             </ac-button>
+            <ac-button theme="primary">
+              <i class="fa fa-home" slot="icon-start"></i>
+              ir
+            </ac-button>
+            <ac-button icon-only>
+              <i class="fa fa-home"></i>
+            </ac-button>
             <ac-check label="Ative aqui" helper-text="Testando texto de ajuda"></ac-check>
             <ac-check label="teste" helper-text="Testando texto de ajuda" disabled></ac-check>
             <ac-check label="teste" helper-text="Testando texto de ajuda" disabled checked></ac-check>


### PR DESCRIPTION
Modified due to changes on spacing rules on the design system.

## Proposed changes:
- Buttons should have at least 100px width.
  * Except on icon-only and small buttons.
- Icons on the button should have 16px from the border and 8px from the label.
  * Except on icon-only and small buttons.
- Label on the button should adjust to the center of the button when width is less than 100px.

## Button label is less than 100px:
##### Button size (100px) and padding (8px):
![cap1](https://user-images.githubusercontent.com/33612042/73095410-470f0b80-3ec1-11ea-93a7-a40f879697b4.png)

##### Label margin (auto) and padding (8px):
![cap2](https://user-images.githubusercontent.com/33612042/73095413-470f0b80-3ec1-11ea-9dd5-96d408d56f56.png)

-----

## Button label is greater than 100px:
##### Button size (186px) and padding (8px):
![cap3](https://user-images.githubusercontent.com/33612042/73095415-47a7a200-3ec1-11ea-811d-80e72e7d1c7c.png)

##### Label margin (0px) and padding (8px):
![cap4](https://user-images.githubusercontent.com/33612042/73095417-47a7a200-3ec1-11ea-81e6-b9406d38aab8.png)

-----

## Buttons with icon:
##### 8px padding and auto button size:
![cap5](https://user-images.githubusercontent.com/33612042/73096292-352e6800-3ec3-11ea-8fb5-73e92026a331.png)
##### Icon with left margin 8px (16px from border):
![cap6](https://user-images.githubusercontent.com/33612042/73096294-352e6800-3ec3-11ea-988e-4a8f807f2ecd.png)
##### Label with 8 px padding (8px space from icon and 16px from border):
![cap7](https://user-images.githubusercontent.com/33612042/73096296-352e6800-3ec3-11ea-847c-ac36de7275b0.png)
##### Label adjusting it self when it's less than 100px:
![cap8](https://user-images.githubusercontent.com/33612042/73096297-35c6fe80-3ec3-11ea-91ef-e009e84e4ee6.png)

